### PR TITLE
Lock gl-shader to 4.2.0 to clear warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/mikolalysenko/gl-error3d",
   "dependencies": {
     "gl-buffer": "^2.1.2",
-    "gl-shader": "^4.2.1",
+    "gl-shader": "4.2.0",
     "gl-vao": "^1.3.0",
     "glslify": "^6.0.2"
   },


### PR DESCRIPTION
In similar fashion to https://github.com/plotly/plotly.js/pull/931, gl-shader@4.2.1 currently breaks several (if not all) 3D gl-vis modules.

cc @dfcreative 