### PR TITLE
discard when opacity is zaro also added support for rgba color - gl-error3d module

### DIFF
--- a/errorbars.js
+++ b/errorbars.js
@@ -157,7 +157,10 @@ i_loop:
         }
         if(c.length === 3) {
           c = [c[0], c[1], c[2], 1]
+        } else if(c.length === 4) {
+          c = [c[0], c[1], c[2], c[3]]
         }
+
         if(isNaN(e[0][j]) || isNaN(e[1][j])) {
           continue
         }

--- a/shaders/fragment.glsl
+++ b/shaders/fragment.glsl
@@ -8,7 +8,10 @@ varying vec3 fragPosition;
 varying vec4 fragColor;
 
 void main() {
-  if (outOfRange(clipBounds[0], clipBounds[1], fragPosition)) discard;
+  if (
+    outOfRange(clipBounds[0], clipBounds[1], fragPosition) ||
+    fragColor.a * opacity == 0.
+  ) discard;
 
   gl_FragColor = opacity * fragColor;
 }


### PR DESCRIPTION
Fix https://github.com/plotly/plotly.js/issues/3494 by discarding fragments that have opacity or alpha equal to zero.
@etpinard 