### PR TITLE
Improve numerical stability of projection

### DIFF
--- a/shaders/vertex.glsl
+++ b/shaders/vertex.glsl
@@ -10,7 +10,7 @@ varying vec3 fragPosition;
 void main() {
   vec4 worldPosition  = model * vec4(position, 1.0);
   worldPosition       = (worldPosition / worldPosition.w) + vec4(capSize * offset, 0.0);
-  gl_Position         = projection * view * worldPosition;
+  gl_Position         = projection * (view * worldPosition);
   fragColor           = color;
   fragPosition        = position;
 }


### PR DESCRIPTION
When the position vector has large values that are cancelled out by large values in the model matrix, it is more numerically stable to first multiply the position by the model matrix instead of multiplying the matrices together first.

This should always yield equivalent or more accurate results.

Helps with https://github.com/plotly/plotly.js/issues/3306
See https://github.com/gl-vis/gl-axes3d/pull/23